### PR TITLE
Fix event listener cleanup in menu component

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -279,18 +279,21 @@ const getPostUrl = (slug: string, pubDate: string | Date): string => {
 };
 
 // Event listeners
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Escape" && isOpen.value) {
+    closeMenu();
+  }
+};
+
 onMounted(() => {
   document.addEventListener("toggle-menu", openMenu);
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && isOpen.value) {
-      closeMenu();
-    }
-  });
+  document.addEventListener("keydown", handleKeydown);
   loadPosts();
 });
 
 onUnmounted(() => {
   document.removeEventListener("toggle-menu", openMenu);
+  document.removeEventListener("keydown", handleKeydown);
   document.body.style.overflow = "";
 });
 </script>


### PR DESCRIPTION
## Summary
- clean up keydown listener when the menu component unmounts

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'astro:content')*

------
https://chatgpt.com/codex/tasks/task_e_6849623b869c83208a5ed9d95169b8f5