### PR TITLE
Add URL helper test

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ npm run dev
 | `npm run build`           | Build production site to `./dist/`         |
 | `npm run preview`         | Preview build locally                      |
 | `npm run astro -- --help` | Get help with Astro CLI                    |
+| `npm test`                | Run unit tests                             |
+
+### Running Tests
+
+```sh
+npm test
+```
 
 ## 📝 Creating Blog Posts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "magenta-motion",
+  "name": "hashblog",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "magenta-motion",
+      "name": "hashblog",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/cloudflare": "^12.5.3",
@@ -19,6 +19,9 @@
         "astro-embed": "^0.9.0",
         "fuse.js": "^7.1.0",
         "vue": "^3.5.16"
+      },
+      "devDependencies": {
+        "tsx": "^4.20.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4507,6 +4510,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -7550,6 +7566,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restructure": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
@@ -8375,6 +8401,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.1.tgz",
+      "integrity": "sha512-JsFUnMHIE+g8KllOvWTrSOwCKM10xLcsesvUQR61znsbrcwZ4U/QaqdymmvTqG5GMD7k2VFv9UG35C4dRy34Ag==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-fest": {
       "version": "4.41.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "node --import tsx --test \"tests/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.5.3",
@@ -20,5 +21,8 @@
     "astro-embed": "^0.9.0",
     "fuse.js": "^7.1.0",
     "vue": "^3.5.16"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.1"
   }
 }

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getPostUrl } from '../src/utils/url.js';
+
+test('getPostUrl generates expected path', () => {
+  const result = getPostUrl('post', new Date('2024-05-13'));
+  assert.equal(result, '/2024/05/post');
+});


### PR DESCRIPTION
## Summary
- add a simple node:test suite
- document how to run tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68496457ea0883208b7dca7cb9171466